### PR TITLE
fix CNAME autogenerated on build

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.franzininho.com.br


### PR DESCRIPTION
essa gambi aqui, resolve aquela parada ali de apagar o `CNAME` toda hora no build.