### PR TITLE
Update Links

### DIFF
--- a/docs/FranzininhoDIY/franzininho-diy.md
+++ b/docs/FranzininhoDIY/franzininho-diy.md
@@ -68,8 +68,7 @@ Para reprodução do projeto ou derivações, é importante verificar os requisi
 
 ### Varejo
 
-- [Robocore](https://www.robocore.net/loja/embarcados/franzininho-diy)
-- [FilipeFlop](https://www.robocore.net/loja/embarcados/franzininho-diy)
+- [Robocore](https://www.robocore.net/busca/Franzininho)
 - [Casa da Robótica](https://www.casadarobotica.com/loja/produto.php?loja=650361&IdProd=4275&parceiro=1821)
 
 ### Atacado


### PR DESCRIPTION
O link da Robocore está quebrado visto que ela não vende mais o Franzininho DIY (achei melhor substituir por um que mostra todos os Franzinhos disponíveis) e o link da FilipeFlop (atual MakerHero) está apontando para o mesmo link da Robocore, a MakerHero também não vende mais o Franzininho.